### PR TITLE
Bump sanitize dependency version

### DIFF
--- a/forspell.gemspec
+++ b/forspell.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'backports', '~> 3.0'
   s.add_dependency 'kramdown', '~> 2.0'
   s.add_dependency 'kramdown-parser-gfm', '~> 1.0'
-  s.add_dependency 'sanitize', '~> 5.0'
+  s.add_dependency 'sanitize', '~> 6.0'
   s.add_dependency 'yard'
   s.add_dependency 'ffi-hunspell'
   s.add_dependency 'parser'


### PR DESCRIPTION
Fixes CVE-2023-23627

> Name: sanitize
> Version: 5.2.3
> CVE: CVE-2023-23627
> GHSA: GHSA-fw3g-2h3j-qmm7
> Criticality: Medium
> URL: https://github.com/rgrove/sanitize/security/advisories/GHSA-fw3g-2h3j-qmm7
> Title: Improper neutralization of `noscript` element content may allow XSS in Sanitize
> Solution: upgrade to '>= 6.0.1'