### PR TITLE
Support of Ruby 3.2

### DIFF
--- a/forspell.gemspec
+++ b/forspell.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'backports', '~> 3.0'
   s.add_dependency 'kramdown', '~> 2.0'
   s.add_dependency 'kramdown-parser-gfm', '~> 1.0'
-  s.add_dependency 'sanitize', '~> 5.0'
+  s.add_dependency 'sanitize', '~> 6.0'
   s.add_dependency 'yard'
   s.add_dependency 'ffi-hunspell'
   s.add_dependency 'parser'

--- a/lib/forspell/file_list.rb
+++ b/lib/forspell/file_list.rb
@@ -36,7 +36,7 @@ module Forspell
     def expand_paths(path)
       if File.directory?(path)
         Dir.glob(File.join(path, '**', "*.{#{EXTENSION_GLOBS.join(',')}}"))
-      elsif File.exists? path
+      elsif File.exist? path
         path
       else
         raise PathLoadError, path


### PR DESCRIPTION
**Changes**

* Upgraded `sanitize` to `~> 6.0` because to have nokogiri `=> 1.12.0` because of [this](https://github.com/rubys/nokogumbo#notice-end-of-life)
* Replaced `File.exists?` with `File.exist?` in `lib/forspell/file_list.rb`